### PR TITLE
Changed imgur public key to env variable

### DIFF
--- a/components/MailForm/DigestForm/Forms.tsx
+++ b/components/MailForm/DigestForm/Forms.tsx
@@ -39,7 +39,7 @@ function LostAndFoundForm({
         const res = await fetch('https://api.imgur.com/3/image', {
             method: 'POST',
             headers: {
-                Authorization: 'Client-ID 197e34bb1737a08',
+                Authorization: `Client-ID ${process.env.NEXT_PUBLIC_IMGUR_API_ID}`,
             },
             body,
         });


### PR DESCRIPTION
[DEV-268]https://linear.app/hoagie/issue/DEV-268/imgur-authorization-client-id

Imgur authorization client id was hard coded in the Stuff forms. Now it uses the env variable NEXT_PUBLIC_IMGUR_API_ID